### PR TITLE
FROS-8 Authorization and User Roles

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ package-lock.json
 
 # testing
 /coverage
+*.http
 
 # next.js
 /.next/

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "autoprefixer": "^10.4.13",
     "eslint": "^8.32.0",
     "postcss": "^8.4.21",
-    "supabase": "^1.37.1",
+    "supabase": "^1.38.7",
     "tailwindcss": "^3.2.4",
     "typescript": "^4.9.4"
   }

--- a/pages/api/v1/server/create.ts
+++ b/pages/api/v1/server/create.ts
@@ -11,30 +11,18 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
       req,
       res,
     });
-    
-    const {
-      data: { user }, error: userError
-    } = await supabaseServerClient.auth.getUser();
 
-    if (user) {
-      const { data: server, error } = await createServer(
-        user.id,
-        req.body.name,
-        req.body.description || null
-      );
-  
-      if (error) {
-        return res.status(400).send({ error });
-      }
+    const { data: server, error } = await createServer(
+      supabaseServerClient,
+      req.body.name,
+      req.body.description || null
+    );
 
-      return res.status(200).send(server);
+    if (error) {
+      return res.status(400).send({ error });
     }
 
-    if (userError) {
-      return res.status(400).send({ userError });
-    }
-
-    return res.status(400).json({ message: 'Invalid request' });
+    return res.status(200).send(server);
   }
 
   else {

--- a/services/invites.service.ts
+++ b/services/invites.service.ts
@@ -58,6 +58,7 @@ export async function createInvite(
 
   // If the urlId is null, we need to generate a random uuid for one
   if (!urlId) {
+    // TODO: Move this to postgres
     urlId = uuidv4();
   }
 

--- a/services/message.service.ts
+++ b/services/message.service.ts
@@ -112,7 +112,7 @@ export async function editMessage(supabase: SupabaseClient<Database>, messageId:
 
   return await supabase
     .from('messages')
-    .update({ content, is_edited: true })
+    .update({ content })
     .eq('id', messageId)
     .single();
 }

--- a/services/message.service.ts
+++ b/services/message.service.ts
@@ -57,46 +57,10 @@ export type MessageWithUsersResponseError = MessageWithUsersResponse['error']
 
 export async function createMessage(supabase: SupabaseClient<Database>, message: UnsavedMessage) {
   const { profile_id, channel_id } = message;
-
-  // Fetch the server_id for channel_id
-  const { data: server_channel, error: serverChannelError } = await supabase
-    .from('channels')
-    .select('server_id')
-    .eq('channel_id', channel_id)
-    .single();
-
-  if (serverChannelError) {
-    console.log('Error fetching server_id for channel_id');
-    console.error(serverChannelError);
-  }
-
-  // Fetch the server_user for author_id
-  const { data: server_user, error: serverUserError } = await supabase
-    .from('server_users')
-    .select('id')
-    .eq('profile_id', profile_id)
-    .eq('server_id', server_channel?.server_id)
-    .single();
-
-  // NOTE: This should never happen, but just in case
-  if (serverUserError) {
-    console.log(`Error fetching server_user for author_id (profile_id: ${profile_id} | server_id: ${server_channel?.server_id})))`);
-    console.error(serverUserError);
-  }
-
-  // Finally with all that info, we may process messages to apply any formatting here
-  let content = sanitizeMessage(message.content);
+  const content = sanitizeMessage(message.content);
 
   return await supabase
-    .from('messages')
-    .insert({
-      content,
-      profile_id,
-      channel_id,
-      author_id: server_user?.id!
-    })
-    .select('*')
-    .single();
+    .rpc('createmessage', { content, p_id: profile_id, c_id: channel_id });
 }
 
 export async function deleteMessage(supabase: SupabaseClient<Database>, messageId: number) {

--- a/services/server.service.ts
+++ b/services/server.service.ts
@@ -128,3 +128,27 @@ export async function isUserInServer(supabase: SupabaseClient<Database>, user_id
 
   return { data: data !== null, error: null };
 }
+
+type IsUserInServerResponse = Awaited<ReturnType<typeof isUserInServer>>;
+export type IsUserInServerResponseSuccess = IsUserInServerResponse['data'];
+export type IsUserInServerResponseError = IsUserInServerResponse['error'];
+
+export async function createRole(supabase: SupabaseClient<Database>, server_id: number, name: string, color: string) {
+  return await supabase
+    .from('roles')
+    .insert({ name, color, server_id })
+    .select()
+    .single();
+}
+
+type CreateRoleResponse = Awaited<ReturnType<typeof createRole>>;
+export type CreateRoleResponseSuccess = CreateRoleResponse['data'];
+export type CreateRoleResponseError = CreateRoleResponse['error'];
+
+export async function getUserPermissions(supabase: SupabaseClient<Database>, user_id: string, server_id: number) {
+  return await supabase
+    .rpc(
+      'get_permission_flags_for_server_user',
+      { s_id: server_id, p_id: user_id }
+    );
+}

--- a/services/server.service.ts
+++ b/services/server.service.ts
@@ -1,7 +1,11 @@
 import { Database } from '@/types/database.supabase';
 import { SupabaseClient } from '@supabase/auth-helpers-nextjs';
 
-export async function createServer(supabase: SupabaseClient<Database>, owner_id: string, name: string, description: string | null) {
+export async function createServer(
+  supabase: SupabaseClient<Database>,
+  name: string,
+  description: string | null
+) {
   // Validate server name is present
   if (!name) {
     return { data: null, error: 'Server name is required' };
@@ -12,20 +16,6 @@ export async function createServer(supabase: SupabaseClient<Database>, owner_id:
     .insert({ name, description })
     .select()
     .single();
-
-  if (dbResp.error) {
-    return dbResp;
-  }
-
-  // Let's add the owner to the server
-  await supabase
-    .from('server_users')
-    .insert({ profile_id: owner_id, server_id: dbResp.data.id, is_owner: true });
-
-  // Now that we have a server, we need to create a default channel for it
-  await supabase
-    .from('channels')
-    .insert({ name: 'general', server_id: dbResp.data.id });
 
   return dbResp;
 }

--- a/services/server.service.ts
+++ b/services/server.service.ts
@@ -142,3 +142,55 @@ export async function getUserPermissions(supabase: SupabaseClient<Database>, use
       { s_id: server_id, p_id: user_id }
     );
 }
+
+type GetUserPermissionsResponse = Awaited<ReturnType<typeof getUserPermissions>>;
+export type GetUserPermissionsResponseSuccess = GetUserPermissionsResponse['data'];
+export type GetUserPermissionsResponseError = GetUserPermissionsResponse['error'];
+
+export async function getServerRoles(supabase: SupabaseClient<Database>, server_id: number) {
+  return await supabase
+    .from('server_roles')
+    .select('*')
+    .eq('server_id', server_id);
+}
+
+type GetServerRolesResponse = Awaited<ReturnType<typeof getServerRoles>>;
+export type GetServerRolesResponseSuccess = GetServerRolesResponse['data'];
+export type GetServerRolesResponseError = GetServerRolesResponse['error'];
+
+export async function banUser(supabase: SupabaseClient<Database>, user_id: string, server_id: number, reason?: string) {
+  return await supabase
+    .from('server_bans')
+    .insert({ profile_id: user_id, server_id, reason })
+    .select()
+    .single();
+}
+
+type BanUserResponse = Awaited<ReturnType<typeof banUser>>;
+export type BanUserResponseSuccess = BanUserResponse['data'];
+export type BanUserResponseError = BanUserResponse['error'];
+
+export async function unbanUser(supabase: SupabaseClient<Database>, user_id: string, server_id: number) {
+  return await supabase
+    .from('server_bans')
+    .delete()
+    .eq('profile_id', user_id)
+    .eq('server_id', server_id);
+}
+
+type UnbanUserResponse = Awaited<ReturnType<typeof unbanUser>>;
+export type UnbanUserResponseSuccess = UnbanUserResponse['data'];
+export type UnbanUserResponseError = UnbanUserResponse['error'];
+
+export async function kickUser(supabase: SupabaseClient<Database>, user_id: string, server_id: number) {
+  return await supabase
+    .from('server_users')
+    .delete()
+    .eq('profile_id', user_id)
+    .eq('server_id', server_id)
+    .select();
+}
+
+type KickUserResponse = Awaited<ReturnType<typeof kickUser>>;
+export type KickUserResponseSuccess = KickUserResponse['data'];
+export type KickUserResponseError = KickUserResponse['error'];

--- a/types/database.supabase.ts
+++ b/types/database.supabase.ts
@@ -9,6 +9,29 @@ export type Json =
 export interface Database {
   public: {
     Tables: {
+      channel_permissions: {
+        Row: {
+          channel_id: number
+          created_at: string
+          id: number
+          permissions: number
+          role_id: number
+        }
+        Insert: {
+          channel_id: number
+          created_at?: string
+          id?: number
+          permissions?: number
+          role_id: number
+        }
+        Update: {
+          channel_id?: number
+          created_at?: string
+          id?: number
+          permissions?: number
+          role_id?: number
+        }
+      }
       channels: {
         Row: {
           channel_id: number
@@ -148,6 +171,29 @@ export interface Database {
           website?: string | null
         }
       }
+      server_bans: {
+        Row: {
+          created_at: string
+          id: number
+          profile_id: string
+          reason: string
+          server_id: number
+        }
+        Insert: {
+          created_at?: string
+          id?: number
+          profile_id: string
+          reason?: string
+          server_id: number
+        }
+        Update: {
+          created_at?: string
+          id?: number
+          profile_id?: string
+          reason?: string
+          server_id?: number
+        }
+      }
       server_invites: {
         Row: {
           created_at: string | null
@@ -182,6 +228,7 @@ export interface Database {
           is_system: boolean
           name: string
           permissions: number
+          position: number
           server_id: number
         }
         Insert: {
@@ -191,6 +238,7 @@ export interface Database {
           is_system?: boolean
           name?: string
           permissions?: number
+          position: number
           server_id: number
         }
         Update: {
@@ -200,6 +248,7 @@ export interface Database {
           is_system?: boolean
           name?: string
           permissions?: number
+          position?: number
           server_id?: number
         }
       }
@@ -223,7 +272,6 @@ export interface Database {
       server_users: {
         Row: {
           id: number
-          is_owner: boolean
           joined_at: string | null
           nickname: string | null
           profile_id: string
@@ -231,7 +279,6 @@ export interface Database {
         }
         Insert: {
           id?: number
-          is_owner?: boolean
           joined_at?: string | null
           nickname?: string | null
           profile_id: string
@@ -239,7 +286,6 @@ export interface Database {
         }
         Update: {
           id?: number
-          is_owner?: boolean
           joined_at?: string | null
           nickname?: string | null
           profile_id?: string
@@ -274,6 +320,24 @@ export interface Database {
       [_ in never]: never
     }
     Functions: {
+      createmessage: {
+        Args: {
+          c_id: number
+          p_id: string
+          content: string
+        }
+        Returns: {
+          author_id: number
+          channel_id: number
+          content: string
+          edited_time: string | null
+          id: number
+          is_edited: boolean
+          is_pinned: boolean
+          profile_id: string
+          sent_time: string
+        }[]
+      }
       get_all_channels_for_user: {
         Args: {
           p_id: string
@@ -281,6 +345,19 @@ export interface Database {
         Returns: {
           channel_id: number
         }[]
+      }
+      get_channel_permissions_for_channel_from_message: {
+        Args: {
+          m_id: number
+        }
+        Returns: number
+      }
+      get_highest_role_position_for_user: {
+        Args: {
+          p_id: string
+          s_id: number
+        }
+        Returns: number
       }
       get_owner_id_of_server_from_message: {
         Args: {
@@ -292,6 +369,12 @@ export interface Database {
         Args: {
           s_id: number
           p_id: string
+        }
+        Returns: number
+      }
+      get_server_id_of_message: {
+        Args: {
+          m_id: number
         }
         Returns: number
       }

--- a/types/database.supabase.ts
+++ b/types/database.supabase.ts
@@ -176,22 +176,28 @@ export interface Database {
       }
       server_roles: {
         Row: {
+          color: string | null
           created_at: string | null
           id: number
+          is_system: boolean
           name: string
           permissions: number
           server_id: number
         }
         Insert: {
+          color?: string | null
           created_at?: string | null
-          id: number
+          id?: number
+          is_system?: boolean
           name?: string
-          permissions: number
+          permissions?: number
           server_id: number
         }
         Update: {
+          color?: string | null
           created_at?: string | null
           id?: number
+          is_system?: boolean
           name?: string
           permissions?: number
           server_id?: number
@@ -275,6 +281,26 @@ export interface Database {
         Returns: {
           channel_id: number
         }[]
+      }
+      get_owner_id_of_server_from_message: {
+        Args: {
+          m_id: number
+        }
+        Returns: string
+      }
+      get_permission_flags_for_server_user: {
+        Args: {
+          s_id: number
+          p_id: string
+        }
+        Returns: number
+      }
+      is_user_in_server: {
+        Args: {
+          p_id: string
+          s_id: number
+        }
+        Returns: boolean
       }
     }
     Enums: {

--- a/types/permissions.ts
+++ b/types/permissions.ts
@@ -1,46 +1,61 @@
 export enum ServerPermissions {
   /**
+   * 0
    * No permissions.
    */
   NONE = 0,
 
   /**
+   * 1
    * The user is the owner of the server.
    */
   OWNER = 1 << 0,
 
   /**
+   * 2
    * Server administrator. Effectively contains all permissions aside from destructive operations such as delete server
    */
   ADMINISTRATOR = 1 << 1,
 
   /**
+   * 4
    * Manage server settings, including server name, description, and icon.
    */
   MANAGE_SERVER = 1 << 2,
 
   /**
+   * 8
    * Manage server channels, including creating, editing, and deleting channels.
    */
   MANAGE_CHANNELS = 1 << 3,
 
   /**
+   * 16
    * This permission allows the user to manage other users by editing their nickname
    */
   MANAGE_USERS = 1 << 4,
 
   /**
+   * 32
    * Manage server roles, including creating, editing, and deleting roles.
    */
   MANAGE_ROLES = 1 << 5,
 
   /**
+   * 64
    * Manage messages, allowing the user to delete other user's messages
    */
   MANAGE_MESSAGES = 1 << 6,
 
   /**
+   * 128
    * Manage invites, allowing the user to create, edit, and delete invites.
    */
   MANAGE_INVITES = 1 << 7,
+
+  /**
+   * 256
+   * Create invites, allowing the user to create invites.
+   */
+  CREATE_INVITES = 1 << 8,
 }

--- a/types/permissions.ts
+++ b/types/permissions.ts
@@ -59,3 +59,29 @@ export enum ServerPermissions {
    */
   CREATE_INVITES = 1 << 8,
 }
+
+export enum ChannelPermissions {
+  /**
+   * 0
+   * No permissions.
+   */
+  NONE = 0,
+
+  /**
+   * 1
+   * Manage messages, allowing the user to delete other user's messages and pin messages.
+   */
+  MANAGE_MESSAGES = 1 << 0,
+
+  /**
+   * 2
+   * User can send messages in the channel.
+   */
+  SEND_MESSAGES = 1 << 1,
+
+  /**
+   * 4
+   * User can read messages in the channel.
+   */
+  READ_MESSAGES = 1 << 0,
+}

--- a/types/permissions.ts
+++ b/types/permissions.ts
@@ -1,0 +1,46 @@
+export enum ServerPermissions {
+  /**
+   * No permissions.
+   */
+  NONE = 0,
+
+  /**
+   * The user is the owner of the server.
+   */
+  OWNER = 1 << 0,
+
+  /**
+   * Server administrator. Effectively contains all permissions aside from destructive operations such as delete server
+   */
+  ADMINISTRATOR = 1 << 1,
+
+  /**
+   * Manage server settings, including server name, description, and icon.
+   */
+  MANAGE_SERVER = 1 << 2,
+
+  /**
+   * Manage server channels, including creating, editing, and deleting channels.
+   */
+  MANAGE_CHANNELS = 1 << 3,
+
+  /**
+   * This permission allows the user to manage other users by editing their nickname
+   */
+  MANAGE_USERS = 1 << 4,
+
+  /**
+   * Manage server roles, including creating, editing, and deleting roles.
+   */
+  MANAGE_ROLES = 1 << 5,
+
+  /**
+   * Manage messages, allowing the user to delete other user's messages
+   */
+  MANAGE_MESSAGES = 1 << 6,
+
+  /**
+   * Manage invites, allowing the user to create, edit, and delete invites.
+   */
+  MANAGE_INVITES = 1 << 7,
+}


### PR DESCRIPTION
Closes #15 

# Authorization + User Roles
This PR implements app-level changes to use in tandem with the new RLS policies to enforce roles and their permissions, likewise channels and their permissions

## API Changes
- Two new enum types outlining both server permissions and channel permissions 
- Cleanup of some services by offloading the multiple requests to postgres functions and calling them with the same args

## Additional Notes:
- Most of the work for this PR is implemented via the Supabase dashboard, the changes here are for us to work with constant defined values in our code for better DX and cleaner self-documentation
- While this PR is open there is still much to do and much cannot be tested until frontend implementation is present
- Once that is done however, I will outline testing instructions in a new issue and most likely set up playwright testing to test browser workflows.