### PR TITLE
Online Presence Tracking

### DIFF
--- a/components/home/PresenceIndicator.tsx
+++ b/components/home/PresenceIndicator.tsx
@@ -6,15 +6,16 @@ export function PresenceIndicator({ userId }: { userId: string }) {
   return (
     <div
       className={`
+        relative
         float-left
         w-4
         h-4
         rounded-full
+        z-10
         ${channel.presenceState()[userId] ? 'bg-green-600' : 'bg-slate-500'}
         border-2
         -mt-3
         mr-2
-        z-10
         border-slate-800/50
       `}
     />

--- a/components/home/PresenceIndicator.tsx
+++ b/components/home/PresenceIndicator.tsx
@@ -1,0 +1,22 @@
+import { useOnlinePresenceRef } from '@/context/ChatCtx';
+
+export function PresenceIndicator({ userId }: { userId: string }) {
+  const channel = useOnlinePresenceRef()!;
+
+  return (
+    <div
+      className={`
+        float-left
+        w-4
+        h-4
+        rounded-full
+        ${channel.presenceState()[userId] ? 'bg-green-600' : 'bg-slate-500'}
+        border-2
+        -mt-3
+        mr-2
+        z-10
+        border-slate-800/50
+      `}
+    />
+  );
+}

--- a/components/home/Server.tsx
+++ b/components/home/Server.tsx
@@ -56,7 +56,7 @@ export default function Server({
 
     };
     handleAsync();
-  }, [server, supabase]);
+  }, [server, supabase, onlinePresenceChannel]);
 
   function joinChannel(e: SyntheticEvent, channelId: number, name: string) {
     e.stopPropagation();

--- a/components/home/Server.tsx
+++ b/components/home/Server.tsx
@@ -7,6 +7,7 @@ import ServersIcon from '../icons/ServersIcon';
 import { useSupabaseClient } from '@supabase/auth-helpers-react';
 import styles from '@/styles/Servers.module.css';
 import Marquee from 'react-fast-marquee';
+import { getServerMemberCount } from '@/services/server.service';
 
 export default function Server({
   server,
@@ -19,6 +20,8 @@ export default function Server({
   const supabase = useSupabaseClient();
   const setChannelId = useChannelIdSetter();
   const setChatName = useChatNameSetter();
+  const [ memberCount, setMemberCount ] = useState(0);
+  const [ onlineCount, setOnlineCount ] = useState(0);
 
   const [isChannelHovered, setIsChannelHovered] = useState(false);
   const [isServerHovered, setIsServerHovered] = useState(false);
@@ -32,6 +35,8 @@ export default function Server({
         const { data } = await getChannelsInServer(supabase, server.server_id);
         setChannels(data);
       }
+
+      setMemberCount(await getServerMemberCount(supabase, server.server_id));
     };
     handleAsync();
   }, [server, supabase]);
@@ -104,7 +109,7 @@ export default function Server({
                 >
                   <span className="p-1 bg-grey-300 rounded-full mr-1"></span>
                   <span>
-                    {renderHardcodedMembers(server.servers.id)} Members
+                    {memberCount} Member{memberCount !== 1 ? 's' : ''}
                   </span>
                 </div>
               </div>
@@ -197,7 +202,7 @@ export default function Server({
                 className={`flex items-center ml-2 ${styles.membersSpacing}`}
               >
                 <span className="p-1 bg-grey-300 rounded-full mr-1"></span>
-                <span>{renderHardcodedMembers(server.servers.id)} Members</span>
+                <span>{memberCount} Member{memberCount !== 1 ? 's' : ''}</span>
               </div>
             </div>
           </div>

--- a/components/home/Server.tsx
+++ b/components/home/Server.tsx
@@ -56,15 +56,6 @@ export default function Server({
     }
     return '1';
   }
-  function renderHardcodedMembers(serverId: any) {
-    if (serverId == 30) {
-      return '3';
-    }
-    else if (serverId == 31) {
-      return '3';
-    }
-    return '1';
-  }
 
   if (expand) {
     return (

--- a/components/home/Server.tsx
+++ b/components/home/Server.tsx
@@ -47,7 +47,7 @@ export default function Server({
       if (!error) {
         for (const profile of onlineData) {
           // @ts-expect-error PostgrestResponseSuccess<Profile> incorrectly assumes that the data is an array of arrays
-          if (onlinePresenceChannel!.presenceState()[profile.id] !== undefined) {
+          if (onlinePresenceChannel.presenceState()[profile.id] !== undefined) {
             onlineUsers++;
           }
         }

--- a/components/icons/UserIcon.tsx
+++ b/components/icons/UserIcon.tsx
@@ -1,32 +1,38 @@
 import { User } from '@/types/dbtypes';
 import Image from 'next/image';
+import { PresenceIndicator } from '../home/PresenceIndicator';
 
 export default function UserIcon({ user }: { user: User }) {
-  if (user.avatar_url) {
-    return (
-      <img
-        src={user.avatar_url}
-        alt={`${user.username}'s avatar`}
-        className='flex-none w-7 h-7 mr-2 rounded-full'
-      />
-    );
-  }
+
   return (
-    <div className="flex-none bg-grey-900 rounded-full mr-3 h-7">
-      <svg
-        xmlns='http://www.w3.org/2000/svg'
-        fill='none'
-        viewBox='0 0 24 24'
-        strokeWidth={1.5}
-        stroke='currentColor'
-        className='w-7 h-7 p-2 '
-      >
-        <path
-          strokeLinecap='round'
-          strokeLinejoin='round'
-          d='M15.75 6a3.75 3.75 0 11-7.5 0 3.75 3.75 0 017.5 0zM4.501 20.118a7.5 7.5 0 0114.998 0A17.933 17.933 0 0112 21.75c-2.676 0-5.216-.584-7.499-1.632z'
-        />
-      </svg>
+    <div>
+      {
+        user.avatar_url ? (
+          <img
+            src={user.avatar_url!}
+            alt={`${user.username}'s avatar`}
+            className='flex-none w-7 h-7 mr-2 rounded-full'
+          />
+        ) : (
+          <div className="flex-none bg-grey-900 rounded-full mr-3 h-7">
+            <svg
+              xmlns='http://www.w3.org/2000/svg'
+              fill='none'
+              viewBox='0 0 24 24'
+              strokeWidth={1.5}
+              stroke='currentColor'
+              className='w-7 h-7 p-2 '
+            >
+              <path
+                strokeLinecap='round'
+                strokeLinejoin='round'
+                d='M15.75 6a3.75 3.75 0 11-7.5 0 3.75 3.75 0 017.5 0zM4.501 20.118a7.5 7.5 0 0114.998 0A17.933 17.933 0 0112 21.75c-2.676 0-5.216-.584-7.499-1.632z'
+              />
+            </svg>
+          </div>
+        )
+      }
+      <PresenceIndicator userId={user.id} />
     </div>
   );
 }

--- a/context/ChatCtx.tsx
+++ b/context/ChatCtx.tsx
@@ -79,5 +79,5 @@ export function useChatNameSetter() {
 
 export function useOnlinePresenceRef() {
   const { onlinePresenceRef } = useContext(ChatCtx);
-  return onlinePresenceRef;
+  return onlinePresenceRef!;
 }

--- a/context/ChatCtx.tsx
+++ b/context/ChatCtx.tsx
@@ -1,3 +1,5 @@
+import { useSupabaseClient, useUser } from '@supabase/auth-helpers-react';
+import { RealtimeChannel } from '@supabase/supabase-js';
 import {
   createContext,
   SetStateAction,
@@ -11,6 +13,7 @@ type ChatCtxValue = {
   setChannelId: Dispatch<SetStateAction<number>>;
   chatName: string;
   setChatName: Dispatch<SetStateAction<string>>;
+  onlinePresenceRef: RealtimeChannel | null;
 };
 
 export const ChatCtxDefaultVal: ChatCtxValue = {
@@ -18,18 +21,36 @@ export const ChatCtxDefaultVal: ChatCtxValue = {
   setChannelId: (state) => {},
   chatName: '',
   setChatName: (state) => {},
+  onlinePresenceRef: null
 };
 
 export const ChatCtx = createContext(ChatCtxDefaultVal);
 
 export function ChatCtxProvider({ children }: { children: React.ReactNode }) {
+  const supabase = useSupabaseClient();
+  const user = useUser();
   const [channelId, setChannelId] = useState(ChatCtxDefaultVal.channelId);
-
   const [chatName, setChatName] = useState(ChatCtxDefaultVal.chatName);
+
+  const onlinePresenceRef = supabase.channel('online-users', {
+    config: {
+      presence: {
+        key: user?.id,
+      },
+    },
+  });
+
+  onlinePresenceRef.subscribe(async (status) => {
+    if (status === 'SUBSCRIBED') {
+      const status = await onlinePresenceRef.track({
+        online_at: new Date().toISOString()
+      });
+    }
+  });
 
   return (
     <ChatCtx.Provider
-      value={{ channelId, setChannelId, chatName, setChatName }}
+      value={{ channelId, setChannelId, chatName, setChatName, onlinePresenceRef }}
     >
       {children}
     </ChatCtx.Provider>
@@ -54,4 +75,9 @@ export function useChatNameValue() {
 export function useChatNameSetter() {
   const { setChatName } = useContext(ChatCtx);
   return setChatName;
+}
+
+export function useOnlinePresenceRef() {
+  const { onlinePresenceRef } = useContext(ChatCtx);
+  return onlinePresenceRef;
 }

--- a/services/server.service.ts
+++ b/services/server.service.ts
@@ -234,3 +234,22 @@ export async function getCurrentUserServerPermissions(
 type GetCurrentUserServerPermissionsResponse = Awaited<ReturnType<typeof getCurrentUserServerPermissions>>;
 export type GetCurrentUserServerPermissionsResponseSuccess = GetCurrentUserServerPermissionsResponse['data'];
 export type GetCurrentUserServerPermissionsResponseError = GetCurrentUserServerPermissionsResponse['error'];
+
+export async function getServerMemberCount(
+  supabase: SupabaseClient<Database>,
+  server_id: number
+) {
+  const { data: server_users, error } = await supabase
+    .from('server_users')
+    .select('*')
+    .eq('server_id', server_id);
+
+  if (error) {
+    console.error(error);
+    return 0;
+  }
+
+  return server_users.length;
+}
+
+type GetServerMemberCountResponse = Awaited<ReturnType<typeof getServerMemberCount>>;

--- a/services/server.service.ts
+++ b/services/server.service.ts
@@ -253,3 +253,10 @@ export async function getServerMemberCount(
 }
 
 type GetServerMemberCountResponse = Awaited<ReturnType<typeof getServerMemberCount>>;
+
+export async function getUsersInServer(
+  supabase: SupabaseClient<Database>,
+  server_id: number
+) {
+  return await supabase.rpc('get_users_in_server', { s_id: server_id });
+}

--- a/types/database.supabase.ts
+++ b/types/database.supabase.ts
@@ -37,6 +37,7 @@ export interface Database {
           channel_id: number
           created_at: string | null
           description: string | null
+          is_media: boolean
           name: string
           server_id: number
         }
@@ -44,6 +45,7 @@ export interface Database {
           channel_id?: number
           created_at?: string | null
           description?: string | null
+          is_media?: boolean
           name: string
           server_id: number
         }
@@ -51,6 +53,7 @@ export interface Database {
           channel_id?: number
           created_at?: string | null
           description?: string | null
+          is_media?: boolean
           name?: string
           server_id?: number
         }
@@ -208,7 +211,7 @@ export interface Database {
           expires_at?: string | null
           id?: number
           server_id: number
-          url_id: string
+          url_id?: string
           uses_remaining?: number | null
         }
         Update: {
@@ -315,6 +318,29 @@ export interface Database {
           name?: string
         }
       }
+      user_plugins: {
+        Row: {
+          id: number
+          is_enabled: boolean
+          profile_id: string
+          settings_data: Json
+          source_url: string
+        }
+        Insert: {
+          id?: number
+          is_enabled?: boolean
+          profile_id: string
+          settings_data?: Json
+          source_url: string
+        }
+        Update: {
+          id?: number
+          is_enabled?: boolean
+          profile_id?: string
+          settings_data?: Json
+          source_url?: string
+        }
+      }
     }
     Views: {
       [_ in never]: never
@@ -384,6 +410,30 @@ export interface Database {
           m_id: number
         }
         Returns: number
+      }
+      get_servers_for_user: {
+        Args: Record<PropertyKey, never>
+        Returns: {
+          created_at: string | null
+          description: string | null
+          id: number
+          image_url: string | null
+          name: string
+        }[]
+      }
+      get_users_in_server: {
+        Args: {
+          s_id: number
+        }
+        Returns: {
+          avatar_url: string | null
+          email: string
+          full_name: string | null
+          id: string
+          updated_at: string | null
+          username: string
+          website: string | null
+        }[]
       }
       is_user_in_server: {
         Args: {


### PR DESCRIPTION
# Online Presence Tracking
This PR introduces online presence, to indicate if a user is online or not using the Supabase Presence API

# API Changes
- Adds a new item to `ChatCtx` - `onlinePresenceRef`, which is a `RealtimeChannel` listening on the `online-users` freq
  - Also adds `useOnlinePresenceRef` as a hook which returns the channel from the context
- Adds the following new services:
  - `getServerMemberCount` - Returns the number of members in a server
  - `getUsersInServer` - Returns the profile objects of all users in the server

# Testing:
- Verify presence works
- Verify online counts/member counts for the server bar works