### PR TITLE
Fix type issues

### DIFF
--- a/components/home/DeleteMsgModal.tsx
+++ b/components/home/DeleteMsgModal.tsx
@@ -6,6 +6,7 @@ import { useSupabaseClient } from '@supabase/auth-helpers-react';
 import styles from '@/styles/Components.module.css';
 import { useEffect } from 'react';
 import Modal from '@/components/home/Modal';
+import { ChatMessageWithUser } from '@/types/dbtypes';
 
 export default function DeleteMsgModal({
   showModal,
@@ -14,7 +15,7 @@ export default function DeleteMsgModal({
   setMessageOptions,
 }: {
   showModal: boolean;
-  message: any;
+  message: ChatMessageWithUser;
   displayTime: string;
   setMessageOptions: Dispatch<SetStateAction<'delete' | 'edit' | null>>;
 }) {

--- a/components/home/Message.tsx
+++ b/components/home/Message.tsx
@@ -7,16 +7,15 @@ import EditIcon from '@/components/icons/EditIcon';
 import { editMessage, deleteMessage } from '@/services/message.service';
 import { useSupabaseClient, useUser } from '@supabase/auth-helpers-react';
 import MessageContent from './MessageContent';
-import styles from '@/styles/Chat.module.css';
 import DeleteMsgModal from '@/components/home/DeleteMsgModal';
+import { ChatMessageWithUser } from '@/types/dbtypes';
 
-// NOTE: Any here because of the way Supabase has incorrectly typed the message object as an array when it is in fact, not.
 export default function Message({
   message,
   collapse_user,
   hasDeletePerms = false,
 }: {
-  message: any;
+  message: ChatMessageWithUser;
   collapse_user: boolean;
   hasDeletePerms?: boolean;
 }) {

--- a/components/home/MessageContent.tsx
+++ b/components/home/MessageContent.tsx
@@ -5,11 +5,7 @@ import remarkBreaks from 'remark-breaks';
 import remarkGfm from 'remark-gfm';
 import remarkMath from 'remark-math';
 
-export default function MessageContent({
-  messageContent,
-}: {
-  messageContent: any;
-}) {
+export default function MessageContent({ messageContent }: { messageContent: string }) {
   return (
     <ReactMarkdown
       components={{

--- a/components/home/Server.tsx
+++ b/components/home/Server.tsx
@@ -10,13 +10,7 @@ import Marquee from 'react-fast-marquee';
 import { getServerMemberCount, getUsersInServer } from '@/services/server.service';
 import { Channel, Server as ServerType } from '@/types/dbtypes';
 
-export default function Server({
-  server,
-  expanded,
-}: {
-  server: ServerType;
-  expanded: number;
-}) {
+export default function Server({ server, expanded }: { server: ServerType, expanded: number }) {
   const expand = expanded == server.id;
   const supabase = useSupabaseClient();
   const setChannelId = useChannelIdSetter();

--- a/components/home/Server.tsx
+++ b/components/home/Server.tsx
@@ -8,15 +8,16 @@ import { useSupabaseClient } from '@supabase/auth-helpers-react';
 import styles from '@/styles/Servers.module.css';
 import Marquee from 'react-fast-marquee';
 import { getServerMemberCount, getUsersInServer } from '@/services/server.service';
+import { Channel, Server } from '@/types/dbtypes';
 
 export default function Server({
   server,
   expanded,
 }: {
-  server: any;
+  server: Server;
   expanded: number;
 }) {
-  const expand = expanded == server.server_id;
+  const expand = expanded == server.id;
   const supabase = useSupabaseClient();
   const setChannelId = useChannelIdSetter();
   const setChatName = useChatNameSetter();
@@ -28,25 +29,24 @@ export default function Server({
   const [isServerHovered, setIsServerHovered] = useState(false);
 
   //TODO: getChannelsInServer
-  const [channels, setChannels] = useState<any>([]);
+  const [channels, setChannels] = useState<Channel[]>([]);
 
   useEffect(() => {
     const handleAsync = async () => {
       if (server) {
-        const { data } = await getChannelsInServer(supabase, server.server_id);
-        setChannels(data);
+        const { data } = await getChannelsInServer(supabase, server.id);
+        setChannels(data!);
       }
 
       // Total Members
-      setMemberCount(await getServerMemberCount(supabase, server.server_id));
+      setMemberCount(await getServerMemberCount(supabase, server.id));
 
       // Now we need to get the online count
-      const { data: onlineData, error } = await getUsersInServer(supabase, server.server_id);
+      const { data: onlineData, error } = await getUsersInServer(supabase, server.id);
 
       let onlineUsers = 0;
       if (!error) {
         for (const profile of onlineData) {
-          // @ts-expect-error PostgrestResponseSuccess<Profile> incorrectly assumes that the data is an array of arrays
           if (onlinePresenceChannel.presenceState()[profile.id] !== undefined) {
             onlineUsers++;
           }
@@ -70,11 +70,11 @@ export default function Server({
         <div className="border-b-2   hover:cursor-pointer border-grey-700 py-2 px-3 flex bg-grey-600 justify-between rounded-xl items-center relative z-10">
           <div className="flex items-center">
             <div className="bg-grey-900 p-2 rounded-xl">
-              <ServersIcon server={server.servers} hovered={false} />
+              <ServersIcon server={server} hovered={false} />
             </div>
             <div className="ml-3">
               <div className="text-lg tracking-wide font-bold max-w-[12ch] overflow-hidden hover:overflow-visible">
-                {server.servers.name.length > 10 ? (
+                {server.name.length > 10 ? (
                   <span
                     onMouseEnter={() => setIsServerHovered(true)}
                     onMouseLeave={() => setIsServerHovered(false)}
@@ -85,14 +85,14 @@ export default function Server({
                         direction={'left'}
                         gradient={false}
                       >
-                        {`${server.servers.name}\u00A0\u00A0\u00A0\u00A0\u00A0\u00A0\u00A0\u00A0\u00A0\u00A0`}
+                        {`${server.name}\u00A0\u00A0\u00A0\u00A0\u00A0\u00A0\u00A0\u00A0\u00A0\u00A0`}
                       </Marquee>
                     ) : (
-                      `${server.servers.name.slice(0, 11)}...`
+                      `${server.name.slice(0, 11)}...`
                     )}
                   </span>
                 ) : (
-                  server.servers.name
+                  server.name
                 )}
               </div>
               <div
@@ -118,7 +118,7 @@ export default function Server({
           </div>
         </div>
         <div className="channels bg-grey-700 rounded-lg relative -top-3 py-4  px-7 ">
-          {channels.map((channel: any, idx: number) => (
+          {channels.map((channel: Channel, idx: number) => (
             <div
               className={`channel flex whitespace-nowrap items-center pt-2 pb-1 px-4 hover:bg-grey-600 hover:cursor-pointer rounded-lg max-w-[192px] ${
                 idx === 0 ? 'mt-2' : ''
@@ -164,11 +164,11 @@ export default function Server({
       <div className="border-b-2 border-grey-700 py-2 px-3 flex justify-between hover:bg-grey-700 hover:rounded-xl items-center">
         <div className="flex items-center">
           <div className={`${styles.serverIcon}  p-2 rounded-xl`}>
-            <ServersIcon hovered={false} server={server.servers} />
+            <ServersIcon hovered={false} server={server} />
           </div>
           <div className="ml-3">
             <div className="text-lg tracking-wide font-bold max-w-[12ch] overflow-hidden hover:overflow-visible">
-              {server.servers.name.length > 10 ? (
+              {server.name.length > 10 ? (
                 <span
                   onMouseEnter={() => setIsServerHovered(true)}
                   onMouseLeave={() => setIsServerHovered(false)}
@@ -179,14 +179,14 @@ export default function Server({
                       direction={'left'}
                       gradient={false}
                     >
-                      {`${server.servers.name}\u00A0\u00A0\u00A0\u00A0\u00A0\u00A0\u00A0\u00A0\u00A0\u00A0`}
+                      {`${server.name}\u00A0\u00A0\u00A0\u00A0\u00A0\u00A0\u00A0\u00A0\u00A0\u00A0`}
                     </Marquee>
                   ) : (
-                    `${server.servers.name.slice(0, 11)}...`
+                    `${server.name.slice(0, 11)}...`
                   )}
                 </span>
               ) : (
-                server.servers.name
+                server.name
               )}
             </div>
             <div

--- a/components/home/Server.tsx
+++ b/components/home/Server.tsx
@@ -8,13 +8,13 @@ import { useSupabaseClient } from '@supabase/auth-helpers-react';
 import styles from '@/styles/Servers.module.css';
 import Marquee from 'react-fast-marquee';
 import { getServerMemberCount, getUsersInServer } from '@/services/server.service';
-import { Channel, Server } from '@/types/dbtypes';
+import { Channel, Server as ServerType } from '@/types/dbtypes';
 
 export default function Server({
   server,
   expanded,
 }: {
-  server: Server;
+  server: ServerType;
   expanded: number;
 }) {
   const expand = expanded == server.id;

--- a/components/home/ServerList.tsx
+++ b/components/home/ServerList.tsx
@@ -87,26 +87,22 @@ export default function ServerList() {
           placeholder="Search"
         ></input>
       </div>
-      {/* TODO: fix idx -> server.id */}
       {servers &&
-        servers.map((server, idx) => {
-          // console.table(server);
-          {
-            /* @ts-expect-error This is valid */
+        servers.map((server) => {
+          if (server) {
+            return (
+              <span
+                key={server.server_id}
+                onClick={() => {
+                  return expanded == server.server_id
+                    ? setExpanded(0)
+                    : setExpanded(server.server_id);
+                }}
+              >
+                <Server server={server.servers} expanded={expanded} />
+              </span>
+            );
           }
-          return (
-            <span
-              key={server.server_id}
-              onClick={() => {
-                //  @ts-expect-error This is valid
-                return expanded == server.server_id
-                  ? setExpanded(0)
-                  : setExpanded(server.server_id);
-              }}
-            >
-              <Server server={server} expanded={expanded} />
-            </span>
-          );
         })}
     </div>
   );

--- a/components/icons/ServersIcon.tsx
+++ b/components/icons/ServersIcon.tsx
@@ -6,10 +6,10 @@ export default function ServersIcon({
   width = 6,
   height = 6,
 }: {
-  server: Server | null;
+  server: Server;
   hovered: boolean;
-  width: number;
-  height: number;
+  width?: number;
+  height?: number;
 }) {
   if (server && server.image_url) {
     return (

--- a/services/channels.service.ts
+++ b/services/channels.service.ts
@@ -1,4 +1,5 @@
 import { Database } from '@/types/database.supabase';
+import { Channel } from '@/types/dbtypes';
 import { SupabaseClient } from '@supabase/supabase-js';
 
 export async function getChannelById(supabase: SupabaseClient<Database>, channelId: number) {
@@ -17,7 +18,8 @@ export async function getChannelsInServer(supabase: SupabaseClient<Database>, se
   return await supabase
     .from('channels')
     .select('*')
-    .eq('server_id', serverId);
+    .eq('server_id', serverId)
+    .returns<Channel>();
 }
 
 type ChannelsInServerResponse = Awaited<ReturnType<typeof getChannelsInServer>>;

--- a/services/message.service.ts
+++ b/services/message.service.ts
@@ -1,7 +1,7 @@
 import { sanitizeMessage } from '@/lib/messageHelpers';
 import { getPagination } from '@/lib/paginationHelper';
 import { Database } from '@/types/database.supabase';
-import { UnsavedMessage } from '@/types/dbtypes';
+import { ChatMessageWithUser, UnsavedMessage } from '@/types/dbtypes';
 import { SupabaseClient } from '@supabase/auth-helpers-nextjs';
 
 export async function getMessagesInChannel(supabase: SupabaseClient<Database>, channelId: number, page: number = 0, pageSize: number = 50) {
@@ -30,14 +30,15 @@ export async function getMessagesInChannelWithUser(
     .select('*, profiles(\*)')
     .eq('channel_id', channelId)
     .order('sent_time', { ascending: false })
-    .range(from, to);
+    .range(from, to)
+    .returns<ChatMessageWithUser>();
 }
 
 type Profiles = Database['public']['Tables']['profiles']['Row'];
 type MessagesWithUsersResponse = Awaited<ReturnType<typeof getMessagesInChannelWithUser>>;
-export type MessagesWithUsersResponseSuccess = MessagesWithUsersResponse['data'] & {
-  profiles: Profiles
-}
+// export type MessagesWithUsersResponseSuccess = MessagesWithUsersResponse['data'] & {
+//   profiles: Profiles
+// }
 export type MessagesWithUsersResponseError = MessagesWithUsersResponse['error']
 
 

--- a/services/server.service.ts
+++ b/services/server.service.ts
@@ -1,4 +1,5 @@
 import { Database } from '@/types/database.supabase';
+import { User } from '@/types/dbtypes';
 import { ServerPermissions } from '@/types/permissions';
 import { SupabaseClient } from '@supabase/auth-helpers-nextjs';
 
@@ -88,8 +89,7 @@ export async function getServersForUser(
 }
 
 type GetServersForUserResponse = Awaited<ReturnType<typeof getServersForUser>>;
-export type GetServersForUserResponseSuccess =
-  GetServersForUserResponse['data'];
+export type GetServersForUserResponseSuccess = GetServersForUserResponse['data'];
 export type GetServersForUserResponseError = GetServersForUserResponse['error'];
 
 export async function getServerForUser(
@@ -258,5 +258,7 @@ export async function getUsersInServer(
   supabase: SupabaseClient<Database>,
   server_id: number
 ) {
-  return await supabase.rpc('get_users_in_server', { s_id: server_id });
+  return await supabase
+    .rpc('get_users_in_server', { s_id: server_id })
+    .returns<User>();
 }

--- a/types/dbtypes.ts
+++ b/types/dbtypes.ts
@@ -1,5 +1,4 @@
-import { MessagesWithUsersResponseSuccess } from '@/services/message.service';
-import { GetServerForUserResponseSuccess, GetServersForUserResponseError, GetServersForUserResponseSuccess } from '@/services/server.service';
+import { GetServerForUserResponseSuccess } from '@/services/server.service';
 import { Database } from './database.supabase';
 
 export type Message = Database['public']['Tables']['messages']['Row'];
@@ -12,9 +11,9 @@ export type ServerUser = Database['public']['Tables']['server_users']['Row'];
 // Custom type modifications for client side
 export type UnsavedMessage = Omit<Message, 'id' | 'created_at' | 'sent_time' | 'is_edited' | 'is_pinned' | 'edited_time' | 'author_id'>;
 
-export type ChatMessageWithUser = MessagesWithUsersResponseSuccess | IStringIndexable;
+export type ChatMessageWithUser = Message & { profiles: User };
 
-export type ServersForUser =  GetServersForUserResponseSuccess | IStringIndexable;
+export type ServersForUser =  { server_id: number } & { servers: Server };
 
 export type ServerForUser = GetServerForUserResponseSuccess | IStringIndexable;
 

--- a/types/dbtypes.ts
+++ b/types/dbtypes.ts
@@ -10,12 +10,8 @@ export type ServerUser = Database['public']['Tables']['server_users']['Row'];
 
 // Custom type modifications for client side
 export type UnsavedMessage = Omit<Message, 'id' | 'created_at' | 'sent_time' | 'is_edited' | 'is_pinned' | 'edited_time' | 'author_id'>;
-
 export type ChatMessageWithUser = Message & { profiles: User };
-
 export type ServersForUser =  { server_id: number } & { servers: Server };
-
-export type ServerForUser = GetServerForUserResponseSuccess | IStringIndexable;
 
 export interface IStringIndexable {
   [key: string]: any

--- a/types/dbtypes.ts
+++ b/types/dbtypes.ts
@@ -1,4 +1,3 @@
-import { GetServerForUserResponseSuccess } from '@/services/server.service';
 import { Database } from './database.supabase';
 
 export type Message = Database['public']['Tables']['messages']['Row'];


### PR DESCRIPTION
# Fix Type Issues
This PR addresses the misinterpreted types exported by supabase. While for most things it works, there are many cases where supabase incorrectly assumed an item is an array when it's not, forcing us to use `any` instead of the true type which negates type-safety

# API Changes
This PR removes extraneous types, like `ServerForUser`, modifes the existing typedefs to be manually created instead of implicit to avoid a circular type alias, and finally cleans up extraneous `// @ts-expect-error`s and removes all appropriate `: any` types