### PR TITLE
bugfix: dynamic chat names in messagebar

### DIFF
--- a/components/home/Chat.tsx
+++ b/components/home/Chat.tsx
@@ -181,6 +181,7 @@ export default function Chat() {
           });
         }}
         disabled={!(userPerms & ChannelPermissions.SEND_MESSAGES)}
+        channelName={chatName}
       />
     </>
   );

--- a/components/home/MessageInput.tsx
+++ b/components/home/MessageInput.tsx
@@ -3,9 +3,11 @@ import styles from '@/styles/Chat.module.css';
 
 export default function MessageInput({
   onSubmit,
+  channelName,
   disabled = false,
 }: {
   onSubmit: Function;
+  channelName: string;
   disabled?: boolean;
 }) {
   const [messageText, setMessageText] = useState('');
@@ -42,7 +44,7 @@ export default function MessageInput({
 
       `}
         disabled={disabled}
-        placeholder="Message general"
+        placeholder={`Message ${channelName}`}
         value={
           disabled
             ? 'You do not have permission to message in this channel'


### PR DESCRIPTION
Fixes a bug where the messagebar only shows `general` as the chat even if the channel name doesn't match