### PR TITLE
Direct Messaging

### DIFF
--- a/components/forms/MiniProfile.tsx
+++ b/components/forms/MiniProfile.tsx
@@ -1,8 +1,10 @@
-import { getServerProfileForUser } from '@/services/profile.service';
-import { getServerIdFromMessageId } from '@/services/server.service';
-import { Role, ServerUser, ServerUserProfile, User } from '@/types/dbtypes';
-import { useSupabaseClient } from '@supabase/auth-helpers-react';
-import { memo, useEffect, useState } from 'react';
+import { useSideBarOptionSetter } from '@/context/SideBarOptionCtx';
+import { getOrCreateDMChannel } from '@/lib/DMChannelHelper';
+import { useAddMessage, useDMChannels, useSetChannel } from '@/lib/store';
+import { createMessage } from '@/services/message.service';
+import { Role, ServerUser, User } from '@/types/dbtypes';
+import { useSupabaseClient, useUser } from '@supabase/auth-helpers-react';
+import { memo, } from 'react';
 import UserIcon from '../icons/UserIcon';
 import { SearchBar } from './Styles';
 
@@ -16,6 +18,12 @@ function WrappedComponent({
   server_user: ServerUser;
   roles: Role[];
 }) {
+  const user = useUser();
+  const supabase = useSupabaseClient();
+  const dmChannels = useDMChannels();
+  const setChannel = useSetChannel();
+  const setSideBarOption = useSideBarOptionSetter();
+
   return (
     <div className="flex flex-col space-y-2 items-center p-3">
       <UserIcon user={profile} className="!w-9 !h-9" />
@@ -42,13 +50,38 @@ function WrappedComponent({
         ))}
       </div>
       <hr />
-      <form>
+      {profile.id !== user?.id && (<form>
         <input
           type="text"
           className={`${SearchBar('bg-grey-900')}`}
           placeholder={`Message @${profile.username}`}
+          onKeyDown={async (e) => {
+            if (e.key === 'Enter') {
+              e.preventDefault();
+              const dmChannel = await getOrCreateDMChannel(
+                supabase,
+                profile,
+                dmChannels,
+                setChannel
+              );
+
+              if (dmChannel) {
+                await createMessage(
+                  supabase,
+                  {
+                    content: (e.target as HTMLInputElement).value,
+                    channel_id: dmChannel.channel_id,
+                    profile_id: user!.id,
+                  }
+                );
+
+                setSideBarOption('friends');
+                setChannel(dmChannel);
+              }
+            }
+          }}
         />
-      </form>
+      </form>)}
     </div>
   );
 }

--- a/components/forms/MiniProfile.tsx
+++ b/components/forms/MiniProfile.tsx
@@ -54,7 +54,7 @@ function WrappedComponent({
         <input
           type="text"
           className={`${SearchBar('bg-grey-900')}`}
-          placeholder={`Message @${profile.username}`}
+          placeholder={`Message ${profile.username}`}
           onKeyDown={async (e) => {
             if (e.key === 'Enter') {
               e.preventDefault();

--- a/components/forms/MiniProfile.tsx
+++ b/components/forms/MiniProfile.tsx
@@ -1,6 +1,6 @@
 import { useSideBarOptionSetter } from '@/context/SideBarOptionCtx';
 import { getOrCreateDMChannel } from '@/lib/DMChannelHelper';
-import { useAddDMChannel, useDMChannels, useSetChannel } from '@/lib/store';
+import { useDMChannels, useSetChannel } from '@/lib/store';
 import { createMessage } from '@/services/message.service';
 import { Role, ServerUser, User } from '@/types/dbtypes';
 import { useSupabaseClient, useUser } from '@supabase/auth-helpers-react';
@@ -23,7 +23,6 @@ function WrappedComponent({
   const dmChannels = useDMChannels();
   const setChannel = useSetChannel();
   const setSideBarOption = useSideBarOptionSetter();
-  const addDMChannel = useAddDMChannel();
 
   return (
     <div className="flex flex-col space-y-2 items-center p-3">

--- a/components/forms/MiniProfile.tsx
+++ b/components/forms/MiniProfile.tsx
@@ -1,6 +1,6 @@
 import { useSideBarOptionSetter } from '@/context/SideBarOptionCtx';
 import { getOrCreateDMChannel } from '@/lib/DMChannelHelper';
-import { useAddMessage, useDMChannels, useSetChannel } from '@/lib/store';
+import { useAddDMChannel, useDMChannels, useSetChannel } from '@/lib/store';
 import { createMessage } from '@/services/message.service';
 import { Role, ServerUser, User } from '@/types/dbtypes';
 import { useSupabaseClient, useUser } from '@supabase/auth-helpers-react';
@@ -23,6 +23,7 @@ function WrappedComponent({
   const dmChannels = useDMChannels();
   const setChannel = useSetChannel();
   const setSideBarOption = useSideBarOptionSetter();
+  const addDMChannel = useAddDMChannel();
 
   return (
     <div className="flex flex-col space-y-2 items-center p-3">
@@ -63,8 +64,6 @@ function WrappedComponent({
                 profile,
                 dmChannels
               );
-
-              console.table(dmChannel);
 
               if (dmChannel) {
                 await createMessage(

--- a/components/forms/MiniProfile.tsx
+++ b/components/forms/MiniProfile.tsx
@@ -61,9 +61,10 @@ function WrappedComponent({
               const dmChannel = await getOrCreateDMChannel(
                 supabase,
                 profile,
-                dmChannels,
-                setChannel
+                dmChannels
               );
+
+              console.table(dmChannel);
 
               if (dmChannel) {
                 await createMessage(

--- a/components/home/Chat.tsx
+++ b/components/home/Chat.tsx
@@ -50,7 +50,7 @@ export default function Chat() {
       <div className="border-t-2 mx-5 border-grey-700 flex "></div>
 
       <div
-        className={`${styles.messagesParent}  flex flex-col p-5 bg-grey-800 overflow-y-scroll`}
+        className={`${styles.messagesParent}  flex flex-col p-5 bg-grey-800 overflow-y-auto`}
       >
         <div className={`${styles.messageList} flex flex-col `}>
           {messages &&

--- a/components/home/DMessageList.tsx
+++ b/components/home/DMessageList.tsx
@@ -1,3 +1,65 @@
+import { getAllDMChannels } from '@/services/directmessage.service';
+import { DMChannelWithRecipient } from '@/types/dbtypes';
+import { useSupabaseClient } from '@supabase/auth-helpers-react';
+import { useEffect, useState } from 'react';
+import UserIcon from '../icons/UserIcon';
+import styles from '@/styles/Chat.module.css';
+import { useSetChannel } from '@/lib/store';
+
 export default function DMessageList() {
-  return <>DM List...</>;
+  const supabase = useSupabaseClient();
+  const [ dmChannels, setDMChannels ] = useState<DMChannelWithRecipient[]>([]);
+  const setChannel = useSetChannel();
+
+  // TODO: Move this to store
+  useEffect(() => {
+    async function handleAsync() {
+      const { data, error } = await getAllDMChannels(supabase);
+
+      // console.table(data);
+
+      if (error) {
+        console.error(error);
+      }
+
+      setDMChannels(data || []);
+    }
+
+    handleAsync();
+  }, [supabase]);
+
+  return (
+    <>
+      <div className={`${styles.chatHeader} px-5 pt-5 mb-3`}>
+        <div className="flex flex-row items-center space-x-3">
+          <h1 className="text-3xl font-semibold tracking-wide">
+            Directs
+          </h1>
+        </div>
+      </div>
+      <div className="border-t-2 mx-5 border-grey-700 flex flex-col pt-3">
+        {
+          dmChannels.map((dmChannel) => (
+            <div
+              key={dmChannel.channel_id}
+              className="flex items-center p-2 w-full hover:bg-grey-700 rounded-md transition-colors"
+              onClick={() => {
+                setChannel({
+                  channel_id: dmChannel.channel_id,
+                  server_id: dmChannel.server_id,
+                  name: dmChannel.recipient.username,
+                  is_media: false,
+                  description: null,
+                  created_at: null
+                });
+              }}
+            >
+              <UserIcon user={dmChannel.recipient} className="w-6 h-6" />
+              <div className="ml-2">{dmChannel.recipient.username}</div>
+            </div>
+          ))
+        }
+      </div>
+    </>
+  );
 }

--- a/components/home/DMessageList.tsx
+++ b/components/home/DMessageList.tsx
@@ -2,6 +2,7 @@ import { Channel, DMChannelWithRecipient } from '@/types/dbtypes';
 import UserIcon from '../icons/UserIcon';
 import styles from '@/styles/Chat.module.css';
 import { useDMChannels, useSetChannel } from '@/lib/store';
+import { useEffect, useState } from 'react';
 
 function mapToComponentArray(
   _map: Map<string, DMChannelWithRecipient>,
@@ -35,7 +36,8 @@ function mapToComponentArray(
 }
 export default function DMessageList() {
   const setChannel = useSetChannel();
-  const dmChannels = Array.from(useDMChannels().values());
+  const dmChannels = useDMChannels();
+  console.table(dmChannels);
 
   return (
     <>
@@ -47,25 +49,7 @@ export default function DMessageList() {
         </div>
       </div>
       <div className="border-t-2 mx-5 border-grey-700 flex flex-col pt-3">
-        { dmChannels.map((value) => (
-          <div
-            key={value.channel_id}
-            className="flex items-center p-2 w-full hover:bg-grey-700 rounded-md transition-colors"
-            onClick={() => {
-              setChannel({
-                channel_id: value.channel_id,
-                server_id: value.server_id,
-                name: value.recipient.username,
-                is_media: false,
-                description: null,
-                created_at: null
-              });
-            }}
-          >
-            <UserIcon user={value.recipient} className="!w-6 !h-6"/>
-            <div>{value.recipient.username}</div>
-          </div>
-        ))}
+        { mapToComponentArray(dmChannels, setChannel) }
       </div>
     </>
   );

--- a/components/home/DMessageList.tsx
+++ b/components/home/DMessageList.tsx
@@ -1,30 +1,45 @@
 import { getAllDMChannels } from '@/services/directmessage.service';
-import { DMChannelWithRecipient } from '@/types/dbtypes';
+import { Channel, DMChannelWithRecipient } from '@/types/dbtypes';
 import { useSupabaseClient } from '@supabase/auth-helpers-react';
 import { useEffect, useState } from 'react';
 import UserIcon from '../icons/UserIcon';
 import styles from '@/styles/Chat.module.css';
-import { useSetChannel } from '@/lib/store';
+import { useDMChannels, useSetChannel } from '@/lib/store';
 
+function mapToComponentArray(
+  _map: Map<string, DMChannelWithRecipient>,
+  setChannel: (channel: Channel) => void
+) {
+  const rv = [];
+
+  for (const [key, value] of _map) {
+    rv.push(
+      <div
+        key={value.channel_id}
+        className="flex items-center p-2 w-full hover:bg-grey-700 rounded-md transition-colors"
+        onClick={() => {
+          setChannel({
+            channel_id: value.channel_id,
+            server_id: value.server_id,
+            name: value.recipient.username,
+            is_media: false,
+            description: null,
+            created_at: null
+          });
+        }}
+      >
+        <UserIcon user={value.recipient} className="!w-6 !h-6"/>
+        <div>{value.recipient.username}</div>
+      </div>
+    );
+  }
+
+  return rv;
+}
 export default function DMessageList() {
   const supabase = useSupabaseClient();
-  const [ dmChannels, setDMChannels ] = useState<DMChannelWithRecipient[]>([]);
   const setChannel = useSetChannel();
-
-  // TODO: Move this to store
-  useEffect(() => {
-    async function handleAsync() {
-      const { data, error } = await getAllDMChannels(supabase);
-
-      if (error) {
-        console.error(error);
-      }
-
-      setDMChannels(data || []);
-    }
-
-    handleAsync();
-  }, [supabase]);
+  const dmChannels = useDMChannels();
 
   return (
     <>
@@ -36,27 +51,7 @@ export default function DMessageList() {
         </div>
       </div>
       <div className="border-t-2 mx-5 border-grey-700 flex flex-col pt-3">
-        {
-          dmChannels.map((dmChannel) => (
-            <div
-              key={dmChannel.channel_id}
-              className="flex items-center p-2 w-full hover:bg-grey-700 rounded-md transition-colors"
-              onClick={() => {
-                setChannel({
-                  channel_id: dmChannel.channel_id,
-                  server_id: dmChannel.server_id,
-                  name: dmChannel.recipient.username,
-                  is_media: false,
-                  description: null,
-                  created_at: null
-                });
-              }}
-            >
-              <UserIcon user={dmChannel.recipient} className="!w-6 !h-6"/>
-              <div>{dmChannel.recipient.username}</div>
-            </div>
-          ))
-        }
+        { mapToComponentArray(dmChannels, setChannel) }
       </div>
     </>
   );

--- a/components/home/DMessageList.tsx
+++ b/components/home/DMessageList.tsx
@@ -12,7 +12,7 @@ function mapToComponentArray(
 ) {
   const rv = [];
 
-  for (const [key, value] of _map) {
+  for (const [_, value] of _map) {
     rv.push(
       <div
         key={value.channel_id}

--- a/components/home/DMessageList.tsx
+++ b/components/home/DMessageList.tsx
@@ -2,7 +2,6 @@ import { Channel, DMChannelWithRecipient } from '@/types/dbtypes';
 import UserIcon from '../icons/UserIcon';
 import styles from '@/styles/Chat.module.css';
 import { useDMChannels, useSetChannel } from '@/lib/store';
-import { useEffect, useState } from 'react';
 
 function mapToComponentArray(
   _map: Map<string, DMChannelWithRecipient>,

--- a/components/home/DMessageList.tsx
+++ b/components/home/DMessageList.tsx
@@ -1,7 +1,4 @@
-import { getAllDMChannels } from '@/services/directmessage.service';
 import { Channel, DMChannelWithRecipient } from '@/types/dbtypes';
-import { useSupabaseClient } from '@supabase/auth-helpers-react';
-import { useEffect, useState } from 'react';
 import UserIcon from '../icons/UserIcon';
 import styles from '@/styles/Chat.module.css';
 import { useDMChannels, useSetChannel } from '@/lib/store';
@@ -38,7 +35,7 @@ function mapToComponentArray(
 }
 export default function DMessageList() {
   const setChannel = useSetChannel();
-  const dmChannels = useDMChannels();
+  const dmChannels = Array.from(useDMChannels().values());
 
   return (
     <>
@@ -50,7 +47,25 @@ export default function DMessageList() {
         </div>
       </div>
       <div className="border-t-2 mx-5 border-grey-700 flex flex-col pt-3">
-        { mapToComponentArray(dmChannels, setChannel) }
+        { dmChannels.map((value) => (
+          <div
+            key={value.channel_id}
+            className="flex items-center p-2 w-full hover:bg-grey-700 rounded-md transition-colors"
+            onClick={() => {
+              setChannel({
+                channel_id: value.channel_id,
+                server_id: value.server_id,
+                name: value.recipient.username,
+                is_media: false,
+                description: null,
+                created_at: null
+              });
+            }}
+          >
+            <UserIcon user={value.recipient} className="!w-6 !h-6"/>
+            <div>{value.recipient.username}</div>
+          </div>
+        ))}
       </div>
     </>
   );

--- a/components/home/DMessageList.tsx
+++ b/components/home/DMessageList.tsx
@@ -37,7 +37,6 @@ function mapToComponentArray(
   return rv;
 }
 export default function DMessageList() {
-  const supabase = useSupabaseClient();
   const setChannel = useSetChannel();
   const dmChannels = useDMChannels();
 

--- a/components/home/DMessageList.tsx
+++ b/components/home/DMessageList.tsx
@@ -16,8 +16,6 @@ export default function DMessageList() {
     async function handleAsync() {
       const { data, error } = await getAllDMChannels(supabase);
 
-      // console.table(data);
-
       if (error) {
         console.error(error);
       }
@@ -54,8 +52,8 @@ export default function DMessageList() {
                 });
               }}
             >
-              <UserIcon user={dmChannel.recipient} className="w-6 h-6" />
-              <div className="ml-2">{dmChannel.recipient.username}</div>
+              <UserIcon user={dmChannel.recipient} className="!w-6 !h-6"/>
+              <div>{dmChannel.recipient.username}</div>
             </div>
           ))
         }

--- a/components/home/FriendsList.tsx
+++ b/components/home/FriendsList.tsx
@@ -1,7 +1,6 @@
 import { useRelations } from '@/lib/store';
 import styles from '@/styles/Chat.module.css';
 import { DetailedProfileRelation, ProfileRelationshipType } from '@/types/dbtypes';
-import { useSupabaseClient } from '@supabase/auth-helpers-react';
 import { useEffect, useState } from 'react';
 import { FriendRequestItem } from './FriendRequestItem';
 import { FriendsListItem } from './FriendsListItem';

--- a/components/home/FriendsListItem.tsx
+++ b/components/home/FriendsListItem.tsx
@@ -23,12 +23,15 @@ export function FriendsListItem({ relation }: { relation: DetailedProfileRelatio
         <button
           className="rounded-md p-3 border-2 border-gray-500 hover:bg-gray-500"
           onClick={async () => {
-            await getOrCreateDMChannel(
+            const dmChannel = await getOrCreateDMChannel(
               supabase,
               relation.target_profile,
-              dmChannels,
-              setChannel
+              dmChannels
             );
+
+            if (dmChannel) {
+              setChannel(dmChannel);
+            }
           }}
         >
           <ChannelMessageIcon />

--- a/components/home/FriendsListItem.tsx
+++ b/components/home/FriendsListItem.tsx
@@ -5,12 +5,13 @@ import VerticalSettingsIcon from '../icons/VerticalSettingsIcon';
 import * as DropdownMenu from '@radix-ui/react-dropdown-menu';
 import { removeFriendOrRequest } from '@/services/friends.service';
 import { useSupabaseClient } from '@supabase/auth-helpers-react';
-import { createDM } from '@/services/directmessage.service';
-import { useSetChannel } from '@/lib/store';
+import { useDMChannels, useSetChannel } from '@/lib/store';
+import { getOrCreateDMChannel } from '@/lib/DMChannelHelper';
 
 export function FriendsListItem({ relation }: { relation: DetailedProfileRelation }) {
   const supabase = useSupabaseClient();
   const setChannel = useSetChannel();
+  const dmChannels = useDMChannels();
 
   return (
     <div key={relation.id} className="flex flex-row items-center space-x-3 p-2 w-full hover:bg-grey-900 rounded-md transition-colors">
@@ -22,24 +23,12 @@ export function FriendsListItem({ relation }: { relation: DetailedProfileRelatio
         <button
           className="rounded-md p-3 border-2 border-gray-500 hover:bg-gray-500"
           onClick={async () => {
-            const { data, error } = await createDM(supabase, relation.target_profile.id);
-
-            if (error) {
-              console.error(error);
-              return;
-            }
-
-            // TODO: GET DM CHANNEL IF IT EXISTS FIRST
-            if (data) {
-              setChannel({
-                channel_id: data.channel_id,
-                server_id: data.server_id,
-                name: relation.target_profile.username,
-                is_media: false,
-                description: null,
-                created_at: null
-              });
-            }
+            await getOrCreateDMChannel(
+              supabase,
+              relation.target_profile,
+              dmChannels,
+              setChannel
+            );
           }}
         >
           <ChannelMessageIcon />

--- a/components/home/FriendsListItem.tsx
+++ b/components/home/FriendsListItem.tsx
@@ -5,9 +5,13 @@ import VerticalSettingsIcon from '../icons/VerticalSettingsIcon';
 import * as DropdownMenu from '@radix-ui/react-dropdown-menu';
 import { removeFriendOrRequest } from '@/services/friends.service';
 import { useSupabaseClient } from '@supabase/auth-helpers-react';
+import { createDM } from '@/services/directmessage.service';
+import { useSetChannel } from '@/lib/store';
 
 export function FriendsListItem({ relation }: { relation: DetailedProfileRelation }) {
   const supabase = useSupabaseClient();
+  const setChannel = useSetChannel();
+
   return (
     <div key={relation.id} className="flex flex-row items-center space-x-3 p-2 w-full hover:bg-grey-900 rounded-md transition-colors">
       <UserIcon user={relation.target_profile} />
@@ -17,8 +21,25 @@ export function FriendsListItem({ relation }: { relation: DetailedProfileRelatio
       <div className='flex flex-row space-x-2'>
         <button
           className="rounded-md p-3 border-2 border-gray-500 hover:bg-gray-500"
-          onClick={() => {
-            console.log('DM');
+          onClick={async () => {
+            const { data, error } = await createDM(supabase, relation.target_profile.id);
+
+            if (error) {
+              console.error(error);
+              return;
+            }
+
+            // TODO: GET DM CHANNEL IF IT EXISTS FIRST
+            if (data) {
+              setChannel({
+                channel_id: data.channel_id,
+                server_id: data.server_id,
+                name: relation.target_profile.username,
+                is_media: false,
+                description: null,
+                created_at: null
+              });
+            }
           }}
         >
           <ChannelMessageIcon />

--- a/components/home/MessageHeader.tsx
+++ b/components/home/MessageHeader.tsx
@@ -6,7 +6,6 @@ import * as ContextMenu from '@radix-ui/react-context-menu';
 import { useSupabaseClient, useUser } from '@supabase/auth-helpers-react';
 import { acceptFriendRequest, removeFriendOrRequest, sendFriendRequest } from '@/services/friends.service';
 import { useChannel, useDMChannels, useRelations, useSetChannel } from '@/lib/store';
-import { createDM } from '@/services/directmessage.service';
 import { getOrCreateDMChannel } from '@/lib/DMChannelHelper';
 import { useSideBarOptionSetter } from '@/context/SideBarOptionCtx';
 
@@ -108,14 +107,14 @@ export function MessageHeader({
           <ContextMenu.Item
             className='ContextMenuItem'
             onClick={async () => {
-              await getOrCreateDMChannel(
+              const dmChannel = await getOrCreateDMChannel(
                 supabase,
                 profile,
-                directMessages,
-                setChannel
+                directMessages
               );
 
               setSideBarOption('friends');
+              setChannel(dmChannel);
             }}
             hidden={directMessages.get(profile.id) && directMessages.get(profile.id)!.channel_id === _currentChannel?.channel_id}
           >

--- a/components/home/MessageHeader.tsx
+++ b/components/home/MessageHeader.tsx
@@ -33,7 +33,6 @@ export function MessageHeader({
   const _currentChannel = useChannel();
   const directMessages = useDMChannels();
   const setSideBarOption = useSideBarOptionSetter();
-  // TODO: DMs store so we can create a new DM only if it doesn't exist
 
   return (
     <ContextMenu.Root>

--- a/components/home/MessageHeader.tsx
+++ b/components/home/MessageHeader.tsx
@@ -8,6 +8,7 @@ import { acceptFriendRequest, removeFriendOrRequest, sendFriendRequest } from '@
 import { useChannel, useDMChannels, useRelations, useSetChannel } from '@/lib/store';
 import { createDM } from '@/services/directmessage.service';
 import { getOrCreateDMChannel } from '@/lib/DMChannelHelper';
+import { useSideBarOptionSetter } from '@/context/SideBarOptionCtx';
 
 export function MessageHeader({
   profile,
@@ -31,6 +32,7 @@ export function MessageHeader({
   const setChannel = useSetChannel();
   const _currentChannel = useChannel();
   const directMessages = useDMChannels();
+  const setSideBarOption = useSideBarOptionSetter();
   // TODO: DMs store so we can create a new DM only if it doesn't exist
 
   return (
@@ -113,6 +115,8 @@ export function MessageHeader({
                 directMessages,
                 setChannel
               );
+
+              setSideBarOption('friends');
             }}
             hidden={directMessages.get(profile.id) && directMessages.get(profile.id)!.channel_id === _currentChannel?.channel_id}
           >

--- a/components/home/NavBar.tsx
+++ b/components/home/NavBar.tsx
@@ -54,7 +54,7 @@ export default function NavBar({ type }: { type: 'vertical' | 'bottom' }) {
           height={6}
         />
       </div>
-      <div
+      {/* <div
         className={`${
           type == 'bottom'
             ? `${bottomStyles} col-start-8 col-end-10`
@@ -68,7 +68,7 @@ export default function NavBar({ type }: { type: 'vertical' | 'bottom' }) {
         onMouseLeave={() => setMessagesHover(false)}
       >
         <MessagesIcon hovered={messagesHover} width={6} height={6} />
-      </div>
+      </div> */}
     </>
   );
 }

--- a/components/home/NavBar.tsx
+++ b/components/home/NavBar.tsx
@@ -1,7 +1,6 @@
 import { useSideBarOptionSetter } from '@/context/SideBarOptionCtx';
 import FriendsIcon from '@/components/icons/FriendsIcon';
 import ServersIcon from '@/components/icons/ServersIcon';
-import MessagesIcon from '@/components/icons/MessagesIcon';
 import { useState } from 'react';
 import { useSetChannel } from '@/lib/store';
 
@@ -12,8 +11,6 @@ export default function NavBar({ type }: { type: 'vertical' | 'bottom' }) {
 
   const [friendsHover, setFriendsHover] = useState(false);
   const [serversHover, setServersHover] = useState(false);
-  const [messagesHover, setMessagesHover] = useState(false);
-
   const bottomStyles = 'hover:cursor-pointer flex justify-center items-center';
   const verticalStyles = 'hover:cursor-pointer flex justify-center py-5';
 
@@ -49,7 +46,6 @@ export default function NavBar({ type }: { type: 'vertical' | 'bottom' }) {
       >
         <ServersIcon
           hovered={serversHover}
-          server={null}
           width={6}
           height={6}
         />

--- a/components/home/RenderDesktopView.tsx
+++ b/components/home/RenderDesktopView.tsx
@@ -41,9 +41,9 @@ export function renderContent(
     case 'servers':
       if (channel) return [<ServerList key={1} />, <Chat key={2} />];
       return [<ServerList key={1} />, <DefaultTest key={2} />];
-    case 'messages':
-      if (channel) return [<DMessageList key={1} />, <Chat key={2} />];
-      return [<DMessageList key={1} />, <DefaultTest key={2} />];
+    // case 'messages':
+    //   if (channel) return [<DMessageList key={1} />, <Chat key={2} />];
+    //   return [<DMessageList key={1} />, <DefaultTest key={2} />];
     default:
       return [<FriendsList key={1} />, <DefaultTest key={2} />];
   }

--- a/components/icons/ServersIcon.tsx
+++ b/components/icons/ServersIcon.tsx
@@ -5,8 +5,8 @@ export default function ServersIcon({
   hovered = false,
   className = 'w-6 h-6',
 }: {
-  server: Server;
   hovered: boolean;
+  server?: Server;
   width?: number;
   height?: number;
   className?: string;

--- a/hooks/useRealtimeStore.ts
+++ b/hooks/useRealtimeStore.ts
@@ -177,7 +177,18 @@ export function useRealtimeStore(supabase: SupabaseClient<Database>) {
 
     // add return right here!
     // return serverUsersListener.unsubscribe();
-  }, [addServer, supabase, user, getServers, servers, updateServer, addRelation, updateRelation, removeRelation]);
+  }, [
+    addServer,
+    supabase,
+    user,
+    getServers,
+    servers,
+    updateServer,
+    addRelation,
+    updateRelation,
+    removeRelation,
+    addDMChannel
+  ]);
 
   useEffect(() => {
     if (addMessage && getUserPerms && channel) {

--- a/hooks/useRealtimeStore.ts
+++ b/hooks/useRealtimeStore.ts
@@ -15,6 +15,8 @@ import {
   useServers,
   useUpdateMessage,
   useUpdateServer,
+  useAddDMChannel,
+  useGetDMChannels,
 } from '@/lib/store';
 import { useEffect } from 'react';
 import { Database } from '@/types/database.supabase';
@@ -43,6 +45,8 @@ export function useRealtimeStore(supabase: SupabaseClient<Database>) {
   const removeRelation = useRemoveRelation();
   const getRelations = useGetRelations();
 
+  const addDMChannel = useAddDMChannel();
+  const getDMChannels = useGetDMChannels();
   const user = useUser();
 
   //TODO: CASCADE DELETE ICONS
@@ -87,6 +91,7 @@ export function useRealtimeStore(supabase: SupabaseClient<Database>) {
         )
         .subscribe();
 
+      // START: Entrypoint for always active listeners
       supabase
         .channel('servers')
         .on<Server>(
@@ -134,6 +139,19 @@ export function useRealtimeStore(supabase: SupabaseClient<Database>) {
           async (payload) => {
             console.log('Profile relation delete event');
             removeRelation(supabase, payload.old.id as number);
+          }
+        )
+        .on<Server>(
+          'postgres_changes',
+          {
+            event: 'INSERT',
+            schema: 'public',
+            table: 'servers',
+            filter: 'is_dm=eq.true',
+          },
+          async (payload) => {
+            console.log('DM server insert event');
+            addDMChannel(supabase, payload.new.id);
           }
         )
         .subscribe();
@@ -245,5 +263,6 @@ export function useRealtimeStore(supabase: SupabaseClient<Database>) {
 
   useEffect(() => {
     getRelations(supabase);
-  }, [getRelations, supabase]);
+    getDMChannels(supabase);
+  }, [getRelations, getDMChannels, supabase]);
 }

--- a/lib/DMChannelHelper.ts
+++ b/lib/DMChannelHelper.ts
@@ -16,7 +16,7 @@ export async function getOrCreateDMChannel(
 
   if (channel) {
     setChannel(channel);
-    return;
+    return channel;
   }
 
   // If not, create a new DM channel
@@ -37,4 +37,6 @@ export async function getOrCreateDMChannel(
       created_at: null
     });
   }
+
+  return data;
 }

--- a/lib/DMChannelHelper.ts
+++ b/lib/DMChannelHelper.ts
@@ -8,15 +8,20 @@ import { createDM } from '@/services/directmessage.service';
 export async function getOrCreateDMChannel(
   supabase: SupabaseClient<Database>,
   profile: User,
-  dmChannels: Map<string, DMChannelWithRecipient>,
-  setChannel: (channel: Channel) => void,
+  dmChannels: Map<string, DMChannelWithRecipient>
 ) {
   // First check if we already have a DM channel with this user
   const channel = dmChannels.get(profile.id);
 
   if (channel) {
-    setChannel(channel);
-    return channel;
+    return {
+      channel_id: channel.channel_id,
+      server_id: channel.server_id,
+      name: profile.username,
+      is_media: false,
+      description: null,
+      created_at: null
+    };
   }
 
   // If not, create a new DM channel
@@ -24,19 +29,19 @@ export async function getOrCreateDMChannel(
 
   if (error) {
     console.error(error);
-    return;
+    return null;
   }
 
   if (data) {
-    setChannel({
+    return {
       channel_id: data.channel_id,
       server_id: data.server_id,
       name: profile.username,
       is_media: false,
       description: null,
       created_at: null
-    });
+    };
   }
 
-  return data;
+  return null;
 }

--- a/lib/DMChannelHelper.ts
+++ b/lib/DMChannelHelper.ts
@@ -2,7 +2,6 @@ import { Database } from '@/types/database.supabase';
 import { DMChannelWithRecipient } from '@/types/dbtypes';
 import { User } from '@/types/dbtypes';
 import { SupabaseClient } from '@supabase/supabase-js';
-import { Channel } from '@/types/dbtypes';
 import { createDM } from '@/services/directmessage.service';
 
 export async function getOrCreateDMChannel(

--- a/lib/DMChannelHelper.ts
+++ b/lib/DMChannelHelper.ts
@@ -1,0 +1,40 @@
+import { Database } from '@/types/database.supabase';
+import { DMChannelWithRecipient } from '@/types/dbtypes';
+import { User } from '@/types/dbtypes';
+import { SupabaseClient } from '@supabase/supabase-js';
+import { Channel } from '@/types/dbtypes';
+import { createDM } from '@/services/directmessage.service';
+
+export async function getOrCreateDMChannel(
+  supabase: SupabaseClient<Database>,
+  profile: User,
+  dmChannels: Map<string, DMChannelWithRecipient>,
+  setChannel: (channel: Channel) => void,
+) {
+  // First check if we already have a DM channel with this user
+  const channel = dmChannels.get(profile.id);
+
+  if (channel) {
+    setChannel(channel);
+    return;
+  }
+
+  // If not, create a new DM channel
+  const { data, error } = await createDM(supabase, profile.id);
+
+  if (error) {
+    console.error(error);
+    return;
+  }
+
+  if (data) {
+    setChannel({
+      channel_id: data.channel_id,
+      server_id: data.server_id,
+      name: profile.username,
+      is_media: false,
+      description: null,
+      created_at: null
+    });
+  }
+}

--- a/lib/store.ts
+++ b/lib/store.ts
@@ -40,7 +40,7 @@ const useServerStore = create<ServerState>()((set) => ({
       return;
     }
 
-    if (data) {
+    if (data && !data.servers.is_dm) {
       set((state) => ({
         servers: [...state.servers, data as ServersForUser],
       }));
@@ -337,14 +337,10 @@ const useDMChannelsStore = create<DMChannelsState>()((set) => ({
       return;
     }
 
-    console.table(data);
     set((state) => ({
       dmChannels: state.dmChannels.set(
         data.recipient.id,
-        {
-          ...data,
-          name: data.recipient.username,
-        }
+        data
       )
     }));
   },

--- a/lib/store.ts
+++ b/lib/store.ts
@@ -338,10 +338,12 @@ const useDMChannelsStore = create<DMChannelsState>()((set) => ({
     }
 
     set((state) => ({
-      dmChannels: state.dmChannels.set(
-        data.recipient.id,
-        data
-      )
+      dmChannels: new Map(
+        state.dmChannels.set(
+          data.recipient.id,
+          data
+        )
+      ),
     }));
   },
 

--- a/lib/store.ts
+++ b/lib/store.ts
@@ -3,9 +3,7 @@ import {
   Channel,
   DetailedProfileRelation,
   MessageWithServerProfile,
-  Server,
   ServersForUser,
-  ServerUser,
 } from '@/types/dbtypes';
 import { Database } from '@/types/database.supabase';
 import { SupabaseClient } from '@supabase/supabase-js';
@@ -16,13 +14,13 @@ import {
   getServersForUser,
 } from '@/services/server.service';
 import {
-  createMessage,
   getMessagesInChannelWithUser,
-  getMessageWithUser,
 } from '@/services/message.service';
 import { getCurrentUserChannelPermissions } from '@/services/channels.service';
 import { getMessageWithServerProfile } from '@/services/profile.service';
 import { getRelationships, relationToDetailedRelation } from '@/services/friends.service';
+import { DMChannelWithRecipient } from '@/types/dbtypes';
+import { getDMChannelFromServerId, getAllDMChannels } from '@/services/directmessage.service';
 
 export interface ServerState {
   servers: ServersForUser[];
@@ -323,6 +321,44 @@ const useOnlineStore = create<OnlineState>()((set) => ({
   },
 }));
 
+export interface DMChannelsState {
+  dmChannels: Map<string, DMChannelWithRecipient>; // Map of profileId -> DMChannel
+  addDMChannel: (supabase: SupabaseClient<Database>, serverId: number) => void;
+  getDMChannels: (supabase: SupabaseClient<Database>) => void;
+}
+
+const useDMChannelsStore = create<DMChannelsState>()((set) => ({
+  dmChannels: new Map(),
+  addDMChannel: async (supabase, serverId) => {
+    const { data, error } = await getDMChannelFromServerId(supabase, serverId);
+
+    if (error) {
+      console.error(error);
+      return;
+    }
+
+    set((state) => ({
+      dmChannels: state.dmChannels.set(
+        data.recipient.id,
+        data
+      )
+    }));
+  },
+
+  getDMChannels: async (supabase) => {
+    const { data, error } = await getAllDMChannels(supabase);
+
+    if (error) {
+      console.error(error);
+      return;
+    }
+
+    set((state) => ({
+      dmChannels: new Map(data.map((channel) => [channel.recipient.id, channel]))
+    }));
+  }
+}));
+
 export const useServers = () => useServerStore((state) => state.servers);
 export const useAddServer = () => useServerStore((state) => state.addServer);
 export const useRemoveServer = () =>
@@ -360,3 +396,6 @@ export const useGetUserPermsForServer = () =>
   useUserPermsStore((state) => state.getUserPermsForServer);
 export const useUserServerPerms = () =>
   useUserPermsStore((state) => state.userServerPerms);
+export const useAddDMChannel = () => useDMChannelsStore((state) => state.addDMChannel);
+export const useDMChannels = () => useDMChannelsStore((state) => state.dmChannels);
+export const useGetDMChannels = () => useDMChannelsStore((state) => state.getDMChannels);

--- a/lib/store.ts
+++ b/lib/store.ts
@@ -337,10 +337,14 @@ const useDMChannelsStore = create<DMChannelsState>()((set) => ({
       return;
     }
 
+    console.table(data);
     set((state) => ({
       dmChannels: state.dmChannels.set(
         data.recipient.id,
-        data
+        {
+          ...data,
+          name: data.recipient.username,
+        }
       )
     }));
   },
@@ -354,7 +358,14 @@ const useDMChannelsStore = create<DMChannelsState>()((set) => ({
     }
 
     set((state) => ({
-      dmChannels: new Map(data.map((channel) => [channel.recipient.id, channel]))
+      dmChannels: new Map(data.map(
+        (channel) => [
+          channel.recipient.id,
+          {
+            ...channel,
+            name: channel.recipient.username,
+          }
+        ]))
     }));
   }
 }));

--- a/services/directmessage.service.ts
+++ b/services/directmessage.service.ts
@@ -1,0 +1,9 @@
+import { Database } from '@/types/database.supabase';
+import { DMChannelWithRecipient } from '@/types/dbtypes';
+import { SupabaseClient } from '@supabase/auth-helpers-nextjs';
+
+export async function getAllDMChannels(supabase: SupabaseClient<Database>) {
+  return await supabase
+    .rpc('get_dm_channels_and_target_profiles')
+    .returns<DMChannelWithRecipient>();
+}

--- a/services/directmessage.service.ts
+++ b/services/directmessage.service.ts
@@ -14,3 +14,10 @@ export async function createDM(supabase: SupabaseClient<Database>, targetId: str
     .returns<DMChannelWithRecipient>()
     .single();
 }
+
+export async function getDMChannelFromServerId(supabase: SupabaseClient<Database>, serverId: number) {
+  return await supabase
+    .rpc('get_dm_channel_and_target_profile_by_server_id', { s_id: serverId })
+    .returns<DMChannelWithRecipient>()
+    .single();
+}

--- a/services/directmessage.service.ts
+++ b/services/directmessage.service.ts
@@ -7,3 +7,10 @@ export async function getAllDMChannels(supabase: SupabaseClient<Database>) {
     .rpc('get_dm_channels_and_target_profiles')
     .returns<DMChannelWithRecipient>();
 }
+
+export async function createDM(supabase: SupabaseClient<Database>, targetId: string) {
+  return await supabase
+    .rpc('create_dm', { t_p_id: targetId })
+    .returns<DMChannelWithRecipient>()
+    .single();
+}

--- a/services/message.service.ts
+++ b/services/message.service.ts
@@ -4,7 +4,7 @@ import { Database } from '@/types/database.supabase';
 import { MessageWithServerProfile, UnsavedMessage } from '@/types/dbtypes';
 import { SupabaseClient } from '@supabase/auth-helpers-nextjs';
 
-export async function getMessagesInChannel(supabase: SupabaseClient<Database>, channelId: number, page: number = 0, pageSize: number = 50) {
+export async function getMessagesInChannel(supabase: SupabaseClient<Database>, channelId: number, page: number = 0, pageSize: number = 100) {
   // Paginate
   const { from, to } = getPagination(page, pageSize);
 

--- a/services/profile.service.ts
+++ b/services/profile.service.ts
@@ -99,7 +99,5 @@ export async function getMessageWithServerProfile(supabase: SupabaseClient<Datab
     .returns<MessageWithServerProfile>()
     .single();
 
-  console.table(data);
-
   return data;
 }

--- a/services/server.service.ts
+++ b/services/server.service.ts
@@ -84,8 +84,9 @@ export async function getServersForUser(
 ) {
   return await supabase
     .from('server_users')
-    .select('server_id, servers ( * )')
-    .eq('profile_id', user_id);
+    .select('server_id, servers!inner( * )')
+    .eq('profile_id', user_id)
+    .eq('servers.is_dm', false);
 }
 
 type GetServersForUserResponse = Awaited<ReturnType<typeof getServersForUser>>;
@@ -99,7 +100,7 @@ export async function getServerForUser(
 ) {
   return await supabase
     .from('server_users')
-    .select('server_id, servers ( * )')
+    .select('server_id, servers!inner( * )')
     .eq('id', serverUser_id)
     .single();
 }

--- a/services/server.service.ts
+++ b/services/server.service.ts
@@ -1,5 +1,5 @@
 import { Database } from '@/types/database.supabase';
-import { User } from '@/types/dbtypes';
+import { ServersForUser, User } from '@/types/dbtypes';
 import { ServerPermissions } from '@/types/permissions';
 import { SupabaseClient } from '@supabase/auth-helpers-nextjs';
 
@@ -102,6 +102,7 @@ export async function getServerForUser(
     .from('server_users')
     .select('server_id, servers!inner( * )')
     .eq('id', serverUser_id)
+    .returns<ServersForUser>()
     .single();
 }
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,6 +10,7 @@
     "esModuleInterop": true,
     "module": "esnext",
     "moduleResolution": "node",
+    "downlevelIteration": true,
     "resolveJsonModule": true,
     "isolatedModules": true,
     "jsx": "preserve",

--- a/types/database.supabase.ts
+++ b/types/database.supabase.ts
@@ -387,6 +387,16 @@ export interface Database {
           user2: string
         }[]
       }
+      create_dm: {
+        Args: {
+          t_p_id: string
+        }
+        Returns: {
+          channel_id: number
+          server_id: number
+          recipient: Json
+        }[]
+      }
       createmessage: {
         Args: {
           c_id: number

--- a/types/database.supabase.ts
+++ b/types/database.supabase.ts
@@ -58,58 +58,6 @@ export interface Database {
           server_id?: number
         }
       }
-      direct_message_channels: {
-        Row: {
-          created_at: string
-          id: number
-          owner_id: string
-          recepient_id: string
-        }
-        Insert: {
-          created_at?: string
-          id?: number
-          owner_id: string
-          recepient_id: string
-        }
-        Update: {
-          created_at?: string
-          id?: number
-          owner_id?: string
-          recepient_id?: string
-        }
-      }
-      direct_messages: {
-        Row: {
-          author_id: string
-          content: string
-          direct_message_id: number
-          edited_time: string | null
-          id: number
-          is_edited: boolean
-          is_pinned: boolean
-          sent_time: string
-        }
-        Insert: {
-          author_id: string
-          content: string
-          direct_message_id: number
-          edited_time?: string | null
-          id?: number
-          is_edited?: boolean
-          is_pinned?: boolean
-          sent_time?: string
-        }
-        Update: {
-          author_id?: string
-          content?: string
-          direct_message_id?: number
-          edited_time?: string | null
-          id?: number
-          is_edited?: boolean
-          is_pinned?: boolean
-          sent_time?: string
-        }
-      }
       messages: {
         Row: {
           author_id: number
@@ -449,6 +397,15 @@ export interface Database {
           initiator_profile_id: string
           relationship: Database["public"]["Enums"]["relationship"]
           created_at: string
+        }[]
+      }
+      get_dm_channel_and_target_profile_by_server_id: {
+        Args: {
+          s_id: number
+        }
+        Returns: {
+          channel_id: number
+          recipient: Json
         }[]
       }
       get_dm_channels_and_target_profiles: {

--- a/types/database.supabase.ts
+++ b/types/database.supabase.ts
@@ -97,21 +97,21 @@ export interface Database {
         Row: {
           created_at: string | null
           id: number
-          relationship: Database["public"]["Enums"]["relationship"]
+          relationship: Database['public']['Enums']['relationship']
           user1: string
           user2: string
         }
         Insert: {
           created_at?: string | null
           id?: number
-          relationship: Database["public"]["Enums"]["relationship"]
+          relationship: Database['public']['Enums']['relationship']
           user1: string
           user2: string
         }
         Update: {
           created_at?: string | null
           id?: number
-          relationship?: Database["public"]["Enums"]["relationship"]
+          relationship?: Database['public']['Enums']['relationship']
           user1?: string
           user2?: string
         }
@@ -330,7 +330,7 @@ export interface Database {
         Returns: {
           created_at: string | null
           id: number
-          relationship: Database["public"]["Enums"]["relationship"]
+          relationship: Database['public']['Enums']['relationship']
           user1: string
           user2: string
         }[]
@@ -369,7 +369,7 @@ export interface Database {
           id: number
           target_profile: Json
           initiator_profile_id: string
-          relationship: Database["public"]["Enums"]["relationship"]
+          relationship: Database['public']['Enums']['relationship']
           created_at: string
         }[]
       }
@@ -395,7 +395,7 @@ export interface Database {
           id: number
           target_profile: Json
           initiator_profile_id: string
-          relationship: Database["public"]["Enums"]["relationship"]
+          relationship: Database['public']['Enums']['relationship']
           created_at: string
         }[]
       }
@@ -477,7 +477,7 @@ export interface Database {
         Returns: {
           created_at: string | null
           id: number
-          relationship: Database["public"]["Enums"]["relationship"]
+          relationship: Database['public']['Enums']['relationship']
           user1: string
           user2: string
         }[]
@@ -546,7 +546,7 @@ export interface Database {
       }
     }
     Enums: {
-      relationship: "friend_requested" | "friends" | "blocked"
+      relationship: 'friend_requested' | 'friends' | 'blocked'
     }
     CompositeTypes: {
       [_ in never]: never

--- a/types/database.supabase.ts
+++ b/types/database.supabase.ts
@@ -149,21 +149,21 @@ export interface Database {
         Row: {
           created_at: string | null
           id: number
-          relationship: Database['public']['Enums']['relationship']
+          relationship: Database["public"]["Enums"]["relationship"]
           user1: string
           user2: string
         }
         Insert: {
           created_at?: string | null
           id?: number
-          relationship: Database['public']['Enums']['relationship']
+          relationship: Database["public"]["Enums"]["relationship"]
           user1: string
           user2: string
         }
         Update: {
           created_at?: string | null
           id?: number
-          relationship?: Database['public']['Enums']['relationship']
+          relationship?: Database["public"]["Enums"]["relationship"]
           user1?: string
           user2?: string
         }
@@ -327,6 +327,7 @@ export interface Database {
           description: string | null
           id: number
           image_url: string | null
+          is_dm: boolean
           name: string
         }
         Insert: {
@@ -334,6 +335,7 @@ export interface Database {
           description?: string | null
           id?: number
           image_url?: string | null
+          is_dm?: boolean
           name: string
         }
         Update: {
@@ -341,6 +343,7 @@ export interface Database {
           description?: string | null
           id?: number
           image_url?: string | null
+          is_dm?: boolean
           name?: string
         }
       }
@@ -379,7 +382,7 @@ export interface Database {
         Returns: {
           created_at: string | null
           id: number
-          relationship: Database['public']['Enums']['relationship']
+          relationship: Database["public"]["Enums"]["relationship"]
           user1: string
           user2: string
         }[]
@@ -408,7 +411,7 @@ export interface Database {
           id: number
           target_profile: Json
           initiator_profile_id: string
-          relationship: Database['public']['Enums']['relationship']
+          relationship: Database["public"]["Enums"]["relationship"]
           created_at: string
         }[]
       }
@@ -434,8 +437,16 @@ export interface Database {
           id: number
           target_profile: Json
           initiator_profile_id: string
-          relationship: Database['public']['Enums']['relationship']
+          relationship: Database["public"]["Enums"]["relationship"]
           created_at: string
+        }[]
+      }
+      get_dm_channels_and_target_profiles: {
+        Args: Record<PropertyKey, never>
+        Returns: {
+          channel_id: number
+          server_id: number
+          recipient: Json
         }[]
       }
       get_highest_role_position_for_user: {
@@ -499,7 +510,7 @@ export interface Database {
         Returns: {
           created_at: string | null
           id: number
-          relationship: Database['public']['Enums']['relationship']
+          relationship: Database["public"]["Enums"]["relationship"]
           user1: string
           user2: string
         }[]
@@ -541,6 +552,7 @@ export interface Database {
           description: string | null
           id: number
           image_url: string | null
+          is_dm: boolean
           name: string
         }[]
       }
@@ -567,7 +579,7 @@ export interface Database {
       }
     }
     Enums: {
-      relationship: 'friend_requested' | 'friends' | 'blocked'
+      relationship: "friend_requested" | "friends" | "blocked"
     }
     CompositeTypes: {
       [_ in never]: never

--- a/types/dbtypes.ts
+++ b/types/dbtypes.ts
@@ -18,7 +18,7 @@ export type MessageWithServerProfile = Omit<Message, 'profile_id' | 'author_id'>
 export type ServersForUser =  { server_id: number } & { servers: Server };
 export type ServerUserProfile = User & { server_user: ServerUser, roles: Role[]; };
 export type ServerInvite = Invite & { servers: Server };
-export type DMChannelWithRecipient = Channel & { recipient: User };
+export type DMChannelWithRecipient = { channel_id: number, server_id: number, recipient: User };
 
 export interface IStringIndexable {
   [key: string]: any

--- a/types/dbtypes.ts
+++ b/types/dbtypes.ts
@@ -18,6 +18,7 @@ export type MessageWithServerProfile = Omit<Message, 'profile_id' | 'author_id'>
 export type ServersForUser =  { server_id: number } & { servers: Server };
 export type ServerUserProfile = User & { server_user: ServerUser, roles: Role[]; };
 export type ServerInvite = Invite & { servers: Server };
+export type DMChannelWithRecipient = Channel & { recipient: User };
 
 export interface IStringIndexable {
   [key: string]: any


### PR DESCRIPTION
# Direct Messaging
This PR introduces a DM system for you to message users privately in a 1-on-1 chat

# API Changes
- Adds `directmessage.service.ts` which provides services to create/fetch DM channels
- Completes the form in mini profiles allowing you to send a DM from a user's mini profile
- Implements a context menu to open a DM channel with a user (or if one exists, navigate to that one)
- Adds the `Directs` sidebar to the Friends tab
- Removes the message form for the user's own mini profile
- Removes the `messages` tab from the navbar

# Testing
- Verify the context menus when right clicking a user's message header in chat allows you to DM them, and that only one DM channel between you and the recipient can exist (when using it again, you should be navigated to the same DM channel that was made on first use of it)
- Verify the same applies for the message button in the friends list
- Verify you can DM a user from a mini profile by typing in the message bar and hitting enter to send. The same rules from above should apply and you should be navigated to the DM with your message sent
- Verify you cannot see DM channels made by other users that are NOT addressed to you
- Verify DM servers aren't populated in the main serverlist
- Verify the system behaves consistently